### PR TITLE
chore: populate db from gtfs data

### DIFF
--- a/populate-db/.eslintrc.json
+++ b/populate-db/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "semi": 0,
+    "no-console": 0
+  }
+}

--- a/populate-db/index.js
+++ b/populate-db/index.js
@@ -1,0 +1,35 @@
+"use strict"
+
+const fs = require("fs")
+const path = require("path")
+const csvStream = require("csv-stream")
+const jsonStream = require("JSONStream")
+const request = require("request-promise")
+
+const sourceDir = __dirname
+const destDb = process.argv[2] || "http://localhost:8529/_db/_system"
+
+fs.readdirSync(sourceDir)
+  .map(fileName => path.join(sourceDir, fileName))
+  .filter(filePath => path.extname(filePath) === ".txt")
+  .map(csvFilePath => [csvFilePath, path.join(sourceDir, path.basename(csvFilePath, ".txt") + ".json")])
+  .map(([csvFilePath, jsonFilePath]) => [jsonFilePath, convert(csvFilePath, jsonFilePath)])
+  .forEach(([jsonFilePath, stream]) => stream.on("finish", () => importInto(path.basename(jsonFilePath, ".json"), jsonFilePath)))
+
+function convert(pathIn, pathOut) {
+  console.log("converting:", path.basename(pathIn), "=>", path.basename(pathOut))
+  return fs.createReadStream(pathIn)
+    .pipe(csvStream.createStream({delimiter: ",", enclosedChar : '"'}))
+    .pipe(jsonStream.stringify("[\n", ",\n", "\n]\n"))
+    .pipe(fs.createWriteStream(pathOut))
+}
+
+function importInto(collection, jsonFilePath) {
+  console.log("importing into new collection:", path.basename(jsonFilePath), "=>", collection)
+  const documents = require(jsonFilePath)
+  request.delete(`${destDb}/_api/collection/${collection}`)
+    .catch(() => {}) // in case the collection does not exist
+    .then(() => request.post(`${destDb}/_api/collection`, {body: {name: collection}, json: true}))
+    .then(() => request.post(`${destDb}/_api/import?collection=${collection}&type=list`, {body: documents, json: true}))
+    .then(() => console.log("done:", collection))
+}

--- a/populate-db/package.json
+++ b/populate-db/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "raccord-populate-db",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "JSONStream": "^1.1.4",
+    "csv-stream": "^0.1.3",
+    "request": "^2.74.0",
+    "request-promise": "^4.1.1"
+  },
+  "devDependencies": {},
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
- à exécuter depuis le dossier où se trouvent les fichiers GTFS
- attention à ne pas avoir d'autres fichiers .txt dans ce dossier
- nécessite qu'ArangoDB soit démarrée sans authentification
- prends l'url d'ArangoDB en paramètre (`http://localhost:8529/_db/_system` par défaut)
- je ne streame pas le JSON directement dans la requête HTTP parce que...ça ne marche pas :/
