### PR TITLE
refactor: flexbox css

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -28,18 +28,10 @@ export default class App extends Component {
   render () {
     return (
       <div>
-        <div style={{display: 'flex', flexDirection: 'column', height: '800px'}}>
-          <div style={{display: 'flex', flexDirection: 'row', flex: 1}}>
-            <div style={{flex: 1}}>
-              <FalcorPanel content={this.state.falcorRequest} onResponse={response => this.handleResponse(response)} />
-            </div>
-            <div style={{flex: 1}}>
-              <GraphQLPanel onChange={request => this.tryTranslateGraphQL(request)} />
-            </div>
-          </div>
-          <div style={{flex: 1}}>
-            <ResponsePanel content={this.state.response} />
-          </div>
+        <div style={{display: 'flex', flexDirection: 'row', height: '70em'}}>
+          <FalcorPanel content={this.state.falcorRequest} onResponse={response => this.handleResponse(response)} />
+          <GraphQLPanel onChange={request => this.tryTranslateGraphQL(request)} />
+          <ResponsePanel content={this.state.response} />
         </div>
       </div>
     )

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,4 @@
 import React, { Component } from 'react'
-import Header from './Header'
-import ConfigPanel from './ConfigPanel'
 import FalcorPanel from './FalcorPanel'
 import GraphQLPanel from './GraphQLPanel'
 import ResponsePanel from './ResponsePanel'
@@ -30,16 +28,16 @@ export default class App extends Component {
   render () {
     return (
       <div>
-        <Header />
-        <div className="container">
-          <div className="row">
-            <ConfigPanel />
+        <div style={{display: 'flex', flexDirection: 'column', height: '800px'}}>
+          <div style={{display: 'flex', flexDirection: 'row', flex: 1}}>
+            <div style={{flex: 1}}>
+              <FalcorPanel content={this.state.falcorRequest} onResponse={response => this.handleResponse(response)} />
+            </div>
+            <div style={{flex: 1}}>
+              <GraphQLPanel onChange={request => this.tryTranslateGraphQL(request)} />
+            </div>
           </div>
-          <div className="row">
-            <FalcorPanel content={this.state.falcorRequest} onResponse={response => this.handleResponse(response)} />
-            <GraphQLPanel onChange={request => this.tryTranslateGraphQL(request)} />
-          </div>
-          <div className="row">
+          <div style={{flex: 1}}>
             <ResponsePanel content={this.state.response} />
           </div>
         </div>

--- a/client/src/FalcorPanel/index.js
+++ b/client/src/FalcorPanel/index.js
@@ -30,7 +30,7 @@ export default class FalcorPanel extends Component {
           theme="github"
           name="falcor_editor"
           fontSize={15}
-          height="20em"
+          height="68em"
           onChange={this.handleRequest}
           value={this.state.request}
           editorProps={{$blockScrolling: true}}

--- a/client/src/FalcorPanel/index.js
+++ b/client/src/FalcorPanel/index.js
@@ -30,7 +30,6 @@ export default class FalcorPanel extends Component {
           theme="github"
           name="falcor_editor"
           fontSize={15}
-          width="100px"
           height="20em"
           onChange={this.handleRequest}
           value={this.state.request}

--- a/client/src/FalcorPanel/index.js
+++ b/client/src/FalcorPanel/index.js
@@ -23,14 +23,15 @@ export default class FalcorPanel extends Component {
 
   render () {
     return (
-      <div className="col-md-6">
+      <div style={{display: 'flex', flexDirection: 'column', flex: 1}}>
         Falcor
         <AceEditor
           mode="javascript"
           theme="github"
           name="falcor_editor"
           fontSize={15}
-          height="8em"
+          width="100px"
+          height="20em"
           onChange={this.handleRequest}
           value={this.state.request}
           editorProps={{$blockScrolling: true}}

--- a/client/src/FalcorPanel/index.js
+++ b/client/src/FalcorPanel/index.js
@@ -30,6 +30,7 @@ export default class FalcorPanel extends Component {
           theme="github"
           name="falcor_editor"
           fontSize={15}
+          width="200px"
           height="68em"
           onChange={this.handleRequest}
           value={this.state.request}

--- a/client/src/GraphQLPanel/index.js
+++ b/client/src/GraphQLPanel/index.js
@@ -19,14 +19,14 @@ export default class GraphQLPanel extends Component {
 
   render () {
     return (
-      <div>
+      <div style={{display: 'flex', flexDirection: 'column', flex: 1}}>
         GraphQL
         <AceEditor
           mode="javascript"
           theme="github"
           name="graphql_editor"
           fontSize={15}
-          height="20em"
+          height="68em"
           onChange={this.handleRequest}
           value={this.state.request}
           editorProps={{$blockScrolling: true}}

--- a/client/src/GraphQLPanel/index.js
+++ b/client/src/GraphQLPanel/index.js
@@ -26,6 +26,7 @@ export default class GraphQLPanel extends Component {
           theme="github"
           name="graphql_editor"
           fontSize={15}
+          width="200px"
           height="68em"
           onChange={this.handleRequest}
           value={this.state.request}

--- a/client/src/GraphQLPanel/index.js
+++ b/client/src/GraphQLPanel/index.js
@@ -19,14 +19,15 @@ export default class GraphQLPanel extends Component {
 
   render () {
     return (
-      <div className="col-md-6">
+      <div>
         GraphQL
         <AceEditor
           mode="javascript"
           theme="github"
           name="graphql_editor"
           fontSize={15}
-          height="8em"
+          width="100px"
+          height="20em"
           onChange={this.handleRequest}
           value={this.state.request}
           editorProps={{$blockScrolling: true}}

--- a/client/src/GraphQLPanel/index.js
+++ b/client/src/GraphQLPanel/index.js
@@ -26,7 +26,6 @@ export default class GraphQLPanel extends Component {
           theme="github"
           name="graphql_editor"
           fontSize={15}
-          width="100px"
           height="20em"
           onChange={this.handleRequest}
           value={this.state.request}

--- a/client/src/ResponsePanel.js
+++ b/client/src/ResponsePanel.js
@@ -3,8 +3,8 @@ import React, { Component } from 'react'
 export default class ResponsePanel extends Component {
   render () {
     return (
-      <div style={{height: '100%'}}>
-        <textarea value={JSON.stringify(this.props.content, null, 2)} readOnly className="form-control" rows="20"/>
+      <div style={{flex: 1}}>
+        <textarea value={JSON.stringify(this.props.content, null, 2)} readOnly className="form-control" rows="48"/>
       </div>
     )
   }

--- a/client/src/ResponsePanel.js
+++ b/client/src/ResponsePanel.js
@@ -3,8 +3,8 @@ import React, { Component } from 'react'
 export default class ResponsePanel extends Component {
   render () {
     return (
-      <div className="col-xs-12">
-        <textarea value={JSON.stringify(this.props.content, null, 2)} readOnly className="form-control" rows="20" />
+      <div style={{height: '100%'}}>
+        <textarea value={JSON.stringify(this.props.content, null, 2)} readOnly className="form-control" rows="20"/>
       </div>
     )
   }


### PR DESCRIPTION
Au départ c'était pour que les boites soient les plus grandes possibles, puis je me suis rendu compte que les textarea et les AceEditor n'en ont rien à faire :(.

Du coup le flex sert à rien. Mais la PR agrandi quand même les textarea et arange l'appli en 3 colonnes : 

![image](https://cloud.githubusercontent.com/assets/1656170/19683934/e00a0164-9ab4-11e6-82d5-33d211d509b9.png)
