### PR TITLE
feat: strip falcor response json envelope before display

### DIFF
--- a/client/src/FalcorPanel/FalcorPanel.js
+++ b/client/src/FalcorPanel/FalcorPanel.js
@@ -7,7 +7,9 @@ export default class FalcorPanel extends Component {
   }
 
   handleFireRequest () {
-    this.props.model.get(...this.props.request).then(this.props.onResponse)
+    this.props.model.get(...this.props.request)
+      .then(response => response.json)
+      .then(this.props.onResponse)
   }
 
   render () {


### PR DESCRIPTION
Displays

```
{
  "stations": {
    ...
  }
}
```

instead of 

```
{
  "json": {
    "stations": {
      ...
    }
  }
}
```